### PR TITLE
Fix #4: Update bikeshed install steps

### DIFF
--- a/samples/travis.yml
+++ b/samples/travis.yml
@@ -1,12 +1,11 @@
 language: python
 sudo: false
 python:
-  - "2.7"
+  - "3.7"
 
 install:
-  # Setup bikeshed. See https://tabatkins.github.io/bikeshed/#install-linux
-  - git clone https://github.com/tabatkins/bikeshed.git
-  - pip install --editable $PWD/bikeshed
+  # Setup bikeshed. See https://tabatkins.github.io/bikeshed/#install-final
+  - pip install bikeshed
   - bikeshed update
  
 script:


### PR DESCRIPTION
The latest version of bikeshed now require Python 3.7 (or later) and has a new method of installing the latest version.

Update travis.yml to include these new requirements and steps.